### PR TITLE
Fix hadolint issue DL3015 and ignore DL3008

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM google/cloud-sdk:314.0.0-slim
 
 COPY entrypoint.sh /entrypoint.sh
-RUN apt-get install -y gnupg2 git rng-tools && \
+
+# hadolint ignore=DL3008
+RUN apt-get install --no-install-recommends -y gnupg2 git rng-tools && \
     apt-get clean && \
     mkdir -p ~/.ssh && \
     curl -Lso /tmp/gopass.deb https://github.com/gopasspw/gopass/releases/download/v1.10.1/gopass_1.10.1_linux_amd64.deb && \


### PR DESCRIPTION
Fixes `DL3015 Avoid additional packages by specifying --no-install-recommends` and ignores `DL3008 Pin versions in apt get install. Instead of apt-get install <package> use apt-get install <package>=<version>`.